### PR TITLE
feat: Add push constant support for Vulkan, D3D11, and OpenGL backends

### DIFF
--- a/samples/GettingStarted/Program.cs
+++ b/samples/GettingStarted/Program.cs
@@ -16,6 +16,7 @@ namespace GettingStarted
         private static DeviceBuffer _indexBuffer;
         private static Shader[] _shaders;
         private static Pipeline _pipeline;
+        private static bool _useRed = false;
 
         private const string VertexCode = @"
 #version 450
@@ -25,10 +26,17 @@ layout(location = 1) in vec4 Color;
 
 layout(location = 0) out vec4 fsin_Color;
 
+layout(push_constant) uniform _PushConstants {
+    int UseRed;
+} pc;
+
 void main()
 {
     gl_Position = vec4(Position, 0, 1);
-    fsin_Color = Color;
+    if (pc.UseRed == 1)
+        fsin_Color = vec4(1.0, 0.0, 0.0, 1.0);
+    else
+        fsin_Color = Color;
 }";
 
         private const string FragmentCode = @"
@@ -50,7 +58,7 @@ void main()
                 Y = 100,
                 WindowWidth = 960,
                 WindowHeight = 540,
-                WindowTitle = "NeoVeldrid Tutorial"
+                WindowTitle = "NeoVeldrid Tutorial — Press R to toggle red"
             };
             GraphicsDeviceOptions options = new GraphicsDeviceOptions
             {
@@ -69,19 +77,25 @@ void main()
                     "opengles" or "gles" => GraphicsBackend.OpenGLES,
                     _ => throw new InvalidOperationException($"Unknown NEOVELDRID_BACKEND: '{backendEnv}'")
                 };
-            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, backend, out Sdl2Window window, out _graphicsDevice);
+            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, GraphicsBackend.OpenGL, out Sdl2Window window, out _graphicsDevice);
             window.Title = $"{window.Title} ({_graphicsDevice.BackendType})";
+
+            // Toggle _useRed when R is pressed
+            window.KeyDown += keyEvent =>
+            {
+                if (keyEvent.Key == Key.R)
+                {
+                    _useRed = !_useRed;
+                }
+            };
 
             CreateResources();
 
             while (window.Exists)
             {
                 window.PumpEvents();
-
                 if (window.Exists)
-                {
                     Draw();
-                }
             }
 
             DisposeResources();
@@ -98,73 +112,62 @@ void main()
                 new VertexPositionColor(new Vector2(-.75f, -.75f), RgbaFloat.Blue),
                 new VertexPositionColor(new Vector2(.75f, -.75f), RgbaFloat.Yellow)
             };
-            BufferDescription vbDescription = new BufferDescription(
-                4 * VertexPositionColor.SizeInBytes,
-                BufferUsage.VertexBuffer);
-            _vertexBuffer = factory.CreateBuffer(vbDescription);
+            _vertexBuffer = factory.CreateBuffer(new BufferDescription(
+                4 * VertexPositionColor.SizeInBytes, BufferUsage.VertexBuffer));
             _graphicsDevice.UpdateBuffer(_vertexBuffer, 0, quadVertices);
 
             ushort[] quadIndices = { 0, 1, 2, 3 };
-            BufferDescription ibDescription = new BufferDescription(
-                4 * sizeof(ushort),
-                BufferUsage.IndexBuffer);
-            _indexBuffer = factory.CreateBuffer(ibDescription);
+            _indexBuffer = factory.CreateBuffer(new BufferDescription(
+                4 * sizeof(ushort), BufferUsage.IndexBuffer));
             _graphicsDevice.UpdateBuffer(_indexBuffer, 0, quadIndices);
 
             VertexLayoutDescription vertexLayout = new VertexLayoutDescription(
                 new VertexElementDescription("Position", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float2),
                 new VertexElementDescription("Color", VertexElementSemantic.TextureCoordinate, VertexElementFormat.Float4));
 
-            ShaderDescription vertexShaderDesc = new ShaderDescription(
-                ShaderStages.Vertex,
-                Encoding.UTF8.GetBytes(VertexCode),
-                "main");
-            ShaderDescription fragmentShaderDesc = new ShaderDescription(
-                ShaderStages.Fragment,
-                Encoding.UTF8.GetBytes(FragmentCode),
-                "main");
+            _shaders = factory.CreateFromSpirv(
+                new ShaderDescription(ShaderStages.Vertex, Encoding.UTF8.GetBytes(VertexCode), "main", true),
+                new ShaderDescription(ShaderStages.Fragment, Encoding.UTF8.GetBytes(FragmentCode), "main", true));
 
-            _shaders = factory.CreateFromSpirv(vertexShaderDesc, fragmentShaderDesc);
-
-            // Create pipeline
-            GraphicsPipelineDescription pipelineDescription = new GraphicsPipelineDescription();
-            pipelineDescription.BlendState = BlendStateDescription.SingleOverrideBlend;
-            pipelineDescription.DepthStencilState = new DepthStencilStateDescription(
-                depthTestEnabled: true,
-                depthWriteEnabled: true,
-                comparisonKind: ComparisonKind.LessEqual);
-            pipelineDescription.RasterizerState = new RasterizerStateDescription(
-                cullMode: FaceCullMode.Back,
-                fillMode: PolygonFillMode.Solid,
-                frontFace: FrontFace.Clockwise,
-                depthClipEnabled: true,
-                scissorTestEnabled: false);
-            pipelineDescription.PrimitiveTopology = PrimitiveTopology.TriangleStrip;
-            pipelineDescription.ResourceLayouts = System.Array.Empty<ResourceLayout>();
-            pipelineDescription.ShaderSet = new ShaderSetDescription(
-                vertexLayouts: new VertexLayoutDescription[] { vertexLayout },
-                shaders: _shaders);
-            pipelineDescription.Outputs = _graphicsDevice.SwapchainFramebuffer.OutputDescription;
+            GraphicsPipelineDescription pipelineDescription = new GraphicsPipelineDescription
+            {
+                BlendState = BlendStateDescription.SingleOverrideBlend,
+                DepthStencilState = new DepthStencilStateDescription(
+                    depthTestEnabled: true,
+                    depthWriteEnabled: true,
+                    comparisonKind: ComparisonKind.LessEqual),
+                RasterizerState = new RasterizerStateDescription(
+                    cullMode: FaceCullMode.Back,
+                    fillMode: PolygonFillMode.Solid,
+                    frontFace: FrontFace.Clockwise,
+                    depthClipEnabled: true,
+                    scissorTestEnabled: false),
+                PrimitiveTopology = PrimitiveTopology.TriangleStrip,
+                ResourceLayouts = Array.Empty<ResourceLayout>(),
+                ShaderSet = new ShaderSetDescription(
+                    vertexLayouts: new[] { vertexLayout },
+                    shaders: _shaders),
+                Outputs = _graphicsDevice.SwapchainFramebuffer.OutputDescription
+            };
 
             _pipeline = factory.CreateGraphicsPipeline(pipelineDescription);
-
             _commandList = factory.CreateCommandList();
         }
 
         private static void Draw()
         {
-            // Begin() must be called before commands can be issued.
             _commandList.Begin();
-
-            // We want to render directly to the output window.
             _commandList.SetFramebuffer(_graphicsDevice.SwapchainFramebuffer);
             _commandList.ClearColorTarget(0, RgbaFloat.Black);
 
-            // Set all relevant state to draw our quad.
             _commandList.SetVertexBuffer(0, _vertexBuffer);
             _commandList.SetIndexBuffer(_indexBuffer, IndexFormat.UInt16);
             _commandList.SetPipeline(_pipeline);
-            // Issue a Draw command for a single instance with 4 indices.
+
+            // Push the current toggle state — 1 = red, 0 = normal colors
+            int useRed = _useRed ? 1 : 0;
+            _commandList.PushConstants(0, useRed);
+
             _commandList.DrawIndexed(
                 indexCount: 4,
                 instanceCount: 1,
@@ -172,11 +175,8 @@ void main()
                 vertexOffset: 0,
                 instanceStart: 0);
 
-            // End() must be called before commands can be submitted for execution.
             _commandList.End();
             _graphicsDevice.SubmitCommands(_commandList);
-
-            // Once commands have been submitted, the rendered image can be presented to the application window.
             _graphicsDevice.SwapBuffers();
         }
 
@@ -184,9 +184,7 @@ void main()
         {
             _pipeline.Dispose();
             foreach (Shader shader in _shaders)
-            {
                 shader.Dispose();
-            }
             _commandList.Dispose();
             _vertexBuffer.Dispose();
             _indexBuffer.Dispose();

--- a/samples/GettingStarted/Program.cs
+++ b/samples/GettingStarted/Program.cs
@@ -77,7 +77,7 @@ void main()
                     "opengles" or "gles" => GraphicsBackend.OpenGLES,
                     _ => throw new InvalidOperationException($"Unknown NEOVELDRID_BACKEND: '{backendEnv}'")
                 };
-            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, GraphicsBackend.OpenGL, out Sdl2Window window, out _graphicsDevice);
+            NeoVeldridStartup.CreateWindowAndGraphicsDevice(windowCI, options, backend, out Sdl2Window window, out _graphicsDevice);
             window.Title = $"{window.Title} ({_graphicsDevice.BackendType})";
 
             // Toggle _useRed when R is pressed

--- a/samples/GettingStarted/Program.cs
+++ b/samples/GettingStarted/Program.cs
@@ -156,10 +156,14 @@ void main()
 
         private static void Draw()
         {
+            // Begin() must be called before commands can be issued.
             _commandList.Begin();
+
+            // We want to render directly to the output window.
             _commandList.SetFramebuffer(_graphicsDevice.SwapchainFramebuffer);
             _commandList.ClearColorTarget(0, RgbaFloat.Black);
 
+            // Set all relevant state to draw our quad.
             _commandList.SetVertexBuffer(0, _vertexBuffer);
             _commandList.SetIndexBuffer(_indexBuffer, IndexFormat.UInt16);
             _commandList.SetPipeline(_pipeline);
@@ -175,8 +179,11 @@ void main()
                 vertexOffset: 0,
                 instanceStart: 0);
 
+            // End() must be called before commands can be submitted for execution.
             _commandList.End();
             _graphicsDevice.SubmitCommands(_commandList);
+
+            // Once commands have been submitted, the rendered image can be presented to the application window.
             _graphicsDevice.SwapBuffers();
         }
 

--- a/src/NeoVeldrid.SPIRV/GlslCompileOptions.cs
+++ b/src/NeoVeldrid.SPIRV/GlslCompileOptions.cs
@@ -12,6 +12,7 @@ namespace NeoVeldrid.SPIRV
         /// be used as the source of an OpenGL-style GLSL shader, then this property should be set to <see langword="true"/>.
         /// </summary>
         public bool Debug { get; set; }
+
         /// <summary>
         /// An array of <see cref="MacroDefinition"/> which defines the set of preprocessor macros to define when compiling the
         /// GLSL source code.

--- a/src/NeoVeldrid.SPIRV/SpirvCrossCompiler.cs
+++ b/src/NeoVeldrid.SPIRV/SpirvCrossCompiler.cs
@@ -21,6 +21,8 @@ namespace NeoVeldrid.SPIRV
     {
         private static readonly Cross s_cross = Cross.GetApi();
 
+        private const uint PushConstantHlslRegister = 13;
+
         internal static VertexFragmentCompilationResult CompileVertexFragment(
             byte[] vsSpirv, byte[] fsSpirv, CrossCompileTarget target, CrossCompileOptions options)
         {
@@ -75,6 +77,8 @@ namespace NeoVeldrid.SPIRV
                     BuildCombinedImageSamplers(cross, vsCompiler);
                     BuildCombinedImageSamplers(cross, fsCompiler);
                     RenameStageIO(cross, vsCompiler, fsCompiler);
+                    RenamePushConstantsGlsl(cross, vsCompiler);
+                    RenamePushConstantsGlsl(cross, fsCompiler);
                 }
 
                 if (target == CrossCompileTarget.ESSL)
@@ -144,6 +148,7 @@ namespace NeoVeldrid.SPIRV
                 if (target == CrossCompileTarget.GLSL || target == CrossCompileTarget.ESSL)
                 {
                     BuildCombinedImageSamplers(cross, csCompiler);
+                    RenamePushConstantsGlsl(cross, csCompiler);
                 }
 
                 if (target == CrossCompileTarget.ESSL)
@@ -248,6 +253,8 @@ namespace NeoVeldrid.SPIRV
                     cross.CompilerOptionsSetUint(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslVersion, version);
                     cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslES, 0);
                     cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslEnable420PackExtension, 0);
+                    // Force push_constant blocks to emit as a proper UBO instead of plain uniforms
+                    cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslEmitPushConstantAsUniformBuffer, 1);
                     break;
                 }
 
@@ -257,6 +264,8 @@ namespace NeoVeldrid.SPIRV
                     cross.CompilerOptionsSetUint(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslVersion, version);
                     cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslES, 1);
                     cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslEnable420PackExtension, 0);
+                    // Force push_constant blocks to emit as a proper UBO instead of plain uniforms
+                    cross.CompilerOptionsSetBool(opts, Silk.NET.SPIRV.Cross.CompilerOption.GlslEmitPushConstantAsUniformBuffer, 1);
                     break;
                 }
 
@@ -584,16 +593,44 @@ namespace NeoVeldrid.SPIRV
 
             if (count == 0) return;
 
-            // Map push_constant block to register b15 — matches PushConstantSlot in D3D11CommandList
+            // Map push_constant block to register b13 — matches PushConstantSlot in D3D11CommandList
             var rootConstants = new HlslRootConstants
             {
                 Start = 0,
                 End = 128, // Must match PushConstantBufferSize in D3D11CommandList
-                Binding = 15,
+                Binding = PushConstantHlslRegister,
                 Space = 0
             };
 
             Check(cross, null, cross.CompilerHlslSetRootConstantsLayout(compiler, &rootConstants, 1));
+        }
+
+        /// <summary>
+        /// Forces the push_constant block's type name to _PushConstants in the GLSL output
+        /// so OpenGLPipeline.SetupPushConstants can find it via GetUniformBlockIndex.
+        /// spirv-cross does not guarantee preserving the block name during conversion.
+        /// </summary>
+        private static void RenamePushConstantsGlsl(Cross cross, SpvcCompiler* compiler)
+        {
+            if (compiler == null) return;
+
+            SpvcResources* resources = null;
+            Check(cross, null, cross.CompilerCreateShaderResources(compiler, &resources));
+
+            ReflectedResource* pushConstants = null;
+            nuint count = 0;
+            cross.ResourcesGetResourceListForType(
+                resources, ResourceType.PushConstant, &pushConstants, &count);
+
+            for (nuint i = 0; i < count; i++)
+            {
+                // spirv-cross GLSL uses the variable name (Id) as the interface block name,
+                // NOT the type name (BaseTypeId) — this is what GetUniformBlockIndex queries
+                SetNativeName(cross, compiler, pushConstants[i].Id, "_PushConstants");
+
+                // Also set the type name as a fallback in case the spirv-cross version differs
+                SetNativeName(cross, compiler, pushConstants[i].BaseTypeId, "_PushConstants");
+            }
         }
 
         #endregion

--- a/src/NeoVeldrid.SPIRV/SpirvCrossCompiler.cs
+++ b/src/NeoVeldrid.SPIRV/SpirvCrossCompiler.cs
@@ -61,6 +61,13 @@ namespace NeoVeldrid.SPIRV
                 if (target == CrossCompileTarget.HLSL || target == CrossCompileTarget.MSL)
                 {
                     RemapBindingsHlslMsl(cross, allResources, vsCompiler, fsCompiler, target);
+
+                    // Handle push constants separately — they have no descriptor set/binding
+                    if (target == CrossCompileTarget.HLSL)
+                    {
+                        RemapPushConstantsHlsl(cross, vsCompiler);
+                        RemapPushConstantsHlsl(cross, fsCompiler);
+                    }
                 }
 
                 if (target == CrossCompileTarget.GLSL || target == CrossCompileTarget.ESSL)
@@ -126,6 +133,12 @@ namespace NeoVeldrid.SPIRV
                 if (target == CrossCompileTarget.HLSL || target == CrossCompileTarget.MSL)
                 {
                     RemapBindingsHlslMsl(cross, allResources, csCompiler, null, target);
+
+                    // Handle push constants separately — they have no descriptor set/binding
+                    if (target == CrossCompileTarget.HLSL)
+                    {
+                        RemapPushConstantsHlsl(cross, csCompiler);
+                    }
                 }
 
                 if (target == CrossCompileTarget.GLSL || target == CrossCompileTarget.ESSL)
@@ -555,6 +568,32 @@ namespace NeoVeldrid.SPIRV
                     cross.CompilerSetDecoration(compiler, kvp.Value.IDs[0], Decoration.Binding, imageIndex++);
                 }
             }
+        }
+
+        private static void RemapPushConstantsHlsl(Cross cross, SpvcCompiler* compiler)
+        {
+            if (compiler == null) return;
+
+            SpvcResources* resources = null;
+            Check(cross, null, cross.CompilerCreateShaderResources(compiler, &resources));
+
+            ReflectedResource* pushConstants = null;
+            nuint count = 0;
+            cross.ResourcesGetResourceListForType(
+                resources, ResourceType.PushConstant, &pushConstants, &count);
+
+            if (count == 0) return;
+
+            // Map push_constant block to register b15 — matches PushConstantSlot in D3D11CommandList
+            var rootConstants = new HlslRootConstants
+            {
+                Start = 0,
+                End = 128, // Must match PushConstantBufferSize in D3D11CommandList
+                Binding = 15,
+                Space = 0
+            };
+
+            Check(cross, null, cross.CompilerHlslSetRootConstantsLayout(compiler, &rootConstants, 1));
         }
 
         #endregion

--- a/src/NeoVeldrid/CommandList.cs
+++ b/src/NeoVeldrid/CommandList.cs
@@ -902,6 +902,8 @@ namespace NeoVeldrid
         /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
         /// constant buffer on D3D11.
         /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// The maximum portable size of all push constant data is 128 bytes, which is the
+        /// minimum guaranteed by the Vulkan specification.
         /// </summary>
         /// <typeparam name="T">The type of data to push. Must be an unmanaged value type.</typeparam>
         /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
@@ -920,6 +922,8 @@ namespace NeoVeldrid
         /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
         /// constant buffer on D3D11.
         /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// The maximum portable size of all push constant data is 128 bytes, which is the
+        /// minimum guaranteed by the Vulkan specification.
         /// </summary>
         /// <typeparam name="T">The type of data to push. Must be an unmanaged value type.</typeparam>
         /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
@@ -938,6 +942,8 @@ namespace NeoVeldrid
         /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
         /// constant buffer on D3D11.
         /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// The maximum portable size of all push constant data is 128 bytes, which is the
+        /// minimum guaranteed by the Vulkan specification.
         /// </summary>
         /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
         /// <param name="source">A pointer to the data to push.</param>

--- a/src/NeoVeldrid/CommandList.cs
+++ b/src/NeoVeldrid/CommandList.cs
@@ -898,6 +898,69 @@ namespace NeoVeldrid
             uint sizeInBytes);
 
         /// <summary>
+        /// Pushes a small amount of data directly into the command stream for use by shaders.
+        /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
+        /// constant buffer on D3D11.
+        /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// </summary>
+        /// <typeparam name="T">The type of data to push. Must be an unmanaged value type.</typeparam>
+        /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
+        /// <param name="value">The value to push.</param>
+        public unsafe void PushConstants<T>(uint offsetInBytes, T value) where T : unmanaged
+        {
+            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref value));
+            fixed (byte* ptr = &sourceByteRef)
+            {
+                PushConstants(offsetInBytes, (IntPtr)ptr, (uint)sizeof(T));
+            }
+        }
+
+        /// <summary>
+        /// Pushes a small amount of data directly into the command stream for use by shaders.
+        /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
+        /// constant buffer on D3D11.
+        /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// </summary>
+        /// <typeparam name="T">The type of data to push. Must be an unmanaged value type.</typeparam>
+        /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
+        /// <param name="value">A reference to the value to push.</param>
+        public unsafe void PushConstants<T>(uint offsetInBytes, ref T value) where T : unmanaged
+        {
+            ref byte sourceByteRef = ref Unsafe.AsRef<byte>(Unsafe.AsPointer(ref value));
+            fixed (byte* ptr = &sourceByteRef)
+            {
+                PushConstants(offsetInBytes, (IntPtr)ptr, Util.USizeOf<T>());
+            }
+        }
+
+        /// <summary>
+        /// Pushes a small amount of data directly into the command stream for use by shaders.
+        /// This maps to push constants on Vulkan, glUniform on OpenGL, and a Map/Discard
+        /// constant buffer on D3D11.
+        /// A graphics <see cref="Pipeline"/> must be active before this can be called.
+        /// </summary>
+        /// <param name="offsetInBytes">The offset, in bytes, into the push constant block at which data will be written.</param>
+        /// <param name="source">A pointer to the data to push.</param>
+        /// <param name="sizeInBytes">The size of the data to push, in bytes.</param>
+        public void PushConstants(uint offsetInBytes, IntPtr source, uint sizeInBytes)
+        {
+#if VALIDATE_USAGE
+            if (_graphicsPipeline == null)
+            {
+                throw new NeoVeldridException($"A graphics {nameof(Pipeline)} must be active before {nameof(PushConstants)} can be called.");
+            }
+
+            if (sizeInBytes == 0)
+            {
+                return;
+            }
+#endif
+            PushConstantsCore(offsetInBytes, source, sizeInBytes);
+        }
+
+        private protected abstract void PushConstantsCore(uint offsetInBytes, IntPtr source, uint sizeInBytes);
+
+        /// <summary>
         /// Copies a region from the source <see cref="DeviceBuffer"/> to another region in the destination <see cref="DeviceBuffer"/>.
         /// </summary>
         /// <param name="source">The source <see cref="DeviceBuffer"/> from which data will be copied.</param>

--- a/src/NeoVeldrid/D3D11/D3D11CommandList.cs
+++ b/src/NeoVeldrid/D3D11/D3D11CommandList.cs
@@ -48,6 +48,11 @@ namespace NeoVeldrid.D3D11
         private ID3D11DomainShader* _domainShader;
         private ID3D11PixelShader* _pixelShader;
 
+        // Push Constants
+        private ComPtr<ID3D11Buffer> _pushConstantBuffer;
+        private const uint PushConstantBufferSize = 256; // Must be multiple of 16 in D3D11
+        private const uint PushConstantSlot = 15;        // Reserved CB slot
+
         private new D3D11Pipeline _graphicsPipeline;
         private BoundResourceSetInfo[] _graphicsResourceSets = new BoundResourceSetInfo[1];
         // Resource sets are invalidated when a new resource set is bound with an incompatible SRV or UAV.
@@ -121,6 +126,19 @@ namespace NeoVeldrid.D3D11
                 _uda = default;
                 _uda.Handle = pUda;
             }
+
+            // Create the dedicated push constant constant buffer
+            BufferDesc pcBufferDesc = new BufferDesc
+            {
+                ByteWidth = PushConstantBufferSize,
+                Usage = Usage.Dynamic,
+                BindFlags = (uint)BindFlag.ConstantBuffer,
+                CPUAccessFlags = (uint)CpuAccessFlag.Write,
+            };
+            ID3D11Buffer* pPcBuffer;
+            SilkMarshal.ThrowHResult(gd.Device->CreateBuffer(&pcBufferDesc, null, &pPcBuffer));
+            _pushConstantBuffer = default;
+            _pushConstantBuffer.Handle = pPcBuffer;
         }
 
         public ID3D11CommandList* DeviceCommandList => _commandList;
@@ -1372,6 +1390,35 @@ namespace NeoVeldrid.D3D11
             }
         }
 
+        private protected override void PushConstantsCore(uint offsetInBytes, IntPtr source, uint sizeInBytes)
+        {
+            // D3D11 has no native push constants — emulate with a Map/Discard on a
+            // dedicated constant buffer bound to a reserved slot on all shader stages.
+            MappedSubresource mapped;
+            SilkMarshal.ThrowHResult(
+                Ctx->Map(
+                    (ID3D11Resource*)_pushConstantBuffer.Handle,
+                    0,
+                    Map.WriteDiscard,
+                    0,
+                    &mapped));
+
+            Unsafe.CopyBlock(
+                (byte*)mapped.PData + offsetInBytes,
+                source.ToPointer(),
+                sizeInBytes);
+
+            Ctx->Unmap((ID3D11Resource*)_pushConstantBuffer.Handle, 0);
+
+            // Bind to all relevant shader stages at the reserved slot
+            ID3D11Buffer* cb = _pushConstantBuffer.Handle;
+            Ctx->VSSetConstantBuffers(PushConstantSlot, 1, &cb);
+            Ctx->PSSetConstantBuffers(PushConstantSlot, 1, &cb);
+            Ctx->GSSetConstantBuffers(PushConstantSlot, 1, &cb);
+            Ctx->HSSetConstantBuffers(PushConstantSlot, 1, &cb);
+            Ctx->DSSetConstantBuffers(PushConstantSlot, 1, &cb);
+        }
+
         private void UpdateSubresource_Workaround(
             ID3D11Resource* resource,
             int subresource,
@@ -1545,6 +1592,7 @@ namespace NeoVeldrid.D3D11
                 if (_uda.Handle != null) _uda.Dispose();
                 if (_commandList.Handle != null) _commandList.Dispose();
                 if (_context1.Handle != null) _context1.Dispose();
+                if (_pushConstantBuffer.Handle != null) _pushConstantBuffer.Dispose();
                 _context.Dispose();
 
                 foreach (BoundResourceSetInfo boundGraphicsSet in _graphicsResourceSets)

--- a/src/NeoVeldrid/D3D11/D3D11CommandList.cs
+++ b/src/NeoVeldrid/D3D11/D3D11CommandList.cs
@@ -51,7 +51,7 @@ namespace NeoVeldrid.D3D11
         // Push Constants
         private ComPtr<ID3D11Buffer> _pushConstantBuffer;
         private const uint PushConstantBufferSize = 256; // Must be multiple of 16 in D3D11
-        private const uint PushConstantSlot = 15;        // Reserved CB slot
+        private const uint PushConstantSlot = 13;        // Reserved CB slot
 
         private new D3D11Pipeline _graphicsPipeline;
         private BoundResourceSetInfo[] _graphicsResourceSets = new BoundResourceSetInfo[1];

--- a/src/NeoVeldrid/D3D11/D3D11CommandList.cs
+++ b/src/NeoVeldrid/D3D11/D3D11CommandList.cs
@@ -50,7 +50,7 @@ namespace NeoVeldrid.D3D11
 
         // Push Constants
         private ComPtr<ID3D11Buffer> _pushConstantBuffer;
-        private const uint PushConstantBufferSize = 256; // Must be multiple of 16 in D3D11
+        private const uint PushConstantBufferSize = 128; // Must be multiple of 16 in D3D11
         private const uint PushConstantSlot = 13;        // Reserved CB slot
 
         private new D3D11Pipeline _graphicsPipeline;

--- a/src/NeoVeldrid/OpenGL/NoAllocEntryList/NoAllocPushConstantsEntry.cs
+++ b/src/NeoVeldrid/OpenGL/NoAllocEntryList/NoAllocPushConstantsEntry.cs
@@ -1,0 +1,15 @@
+﻿namespace NeoVeldrid.OpenGL.NoAllocEntryList;
+
+internal struct NoAllocPushConstantsEntry
+{
+    public readonly uint OffsetInBytes;
+    public readonly StagingBlock StagingBlock;
+    public readonly uint StagingBlockSize;
+
+    public NoAllocPushConstantsEntry(uint offsetInBytes, StagingBlock stagingBlock, uint stagingBlockSize)
+    {
+        OffsetInBytes = offsetInBytes;
+        StagingBlock = stagingBlock;
+        StagingBlockSize = stagingBlockSize;
+    }
+}

--- a/src/NeoVeldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
+++ b/src/NeoVeldrid/OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs
@@ -91,6 +91,9 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
         private const byte InsertDebugMarkerEntryID = 26;
         private static readonly uint InsertDebugMarkerEntrySize = Util.USizeOf<NoAllocInsertDebugMarkerEntry>();
 
+        private const byte PushConstantsEntryID = 27;
+        private static readonly uint PushConstantsEntrySize = Util.USizeOf<NoAllocPushConstantsEntry>();
+
         public OpenGLCommandList Parent { get; }
 
         public OpenGLNoAllocCommandEntryList(OpenGLCommandList cl)
@@ -334,6 +337,12 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
                             (IntPtr)dataPtr, ube.StagingBlockSize);
                         currentOffset += UpdateBufferEntrySize;
                         break;
+                    case PushConstantsEntryID:
+                        NoAllocPushConstantsEntry pce = Unsafe.ReadUnaligned<NoAllocPushConstantsEntry>(entryBasePtr);
+                        byte* pcDataPtr = (byte*)pce.StagingBlock.Data;
+                        executor.PushConstants(pce.OffsetInBytes, (IntPtr)pcDataPtr, pce.StagingBlockSize);
+                        currentOffset += PushConstantsEntrySize;
+                        break;
                     case CopyBufferEntryID:
                         NoAllocCopyBufferEntry cbe = Unsafe.ReadUnaligned<NoAllocCopyBufferEntry>(entryBasePtr);
                         executor.CopyBuffer(
@@ -530,6 +539,14 @@ namespace NeoVeldrid.OpenGL.NoAllocEntryList
             _stagingBlocks.Add(stagingBlock);
             NoAllocUpdateBufferEntry entry = new NoAllocUpdateBufferEntry(Track(buffer), bufferOffsetInBytes, stagingBlock, sizeInBytes);
             AddEntry(UpdateBufferEntryID, ref entry);
+        }
+
+        public void PushConstants(uint offsetInBytes, IntPtr source, uint sizeInBytes)
+        {
+            StagingBlock stagingBlock = _memoryPool.Stage(source, sizeInBytes);
+            _stagingBlocks.Add(stagingBlock);
+            NoAllocPushConstantsEntry entry = new NoAllocPushConstantsEntry(offsetInBytes, stagingBlock, sizeInBytes);
+            AddEntry(PushConstantsEntryID, ref entry);
         }
 
         public void CopyBuffer(DeviceBuffer source, uint sourceOffset, DeviceBuffer destination, uint destinationOffset, uint sizeInBytes)

--- a/src/NeoVeldrid/OpenGL/OpenGLCommandEntryList.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLCommandEntryList.cs
@@ -24,6 +24,7 @@ namespace NeoVeldrid.OpenGL
         void SetViewport(uint index, ref Viewport viewport);
         void ResolveTexture(Texture source, Texture destination);
         void UpdateBuffer(DeviceBuffer buffer, uint bufferOffsetInBytes, IntPtr source, uint sizeInBytes);
+        void PushConstants(uint offsetInBytes, IntPtr source, uint sizeInBytes);
         void ExecuteAll(OpenGLCommandExecutor executor);
         void DispatchIndirect(DeviceBuffer indirectBuffer, uint offset);
         void CopyBuffer(DeviceBuffer source, uint sourceOffset, DeviceBuffer destination, uint destinationOffset, uint sizeInBytes);

--- a/src/NeoVeldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -1165,6 +1165,49 @@ namespace NeoVeldrid.OpenGL
             }
         }
 
+        public void PushConstants(uint offsetInBytes, IntPtr dataPtr, uint sizeInBytes)
+        {
+            OpenGLPipeline pipeline = _graphicsPipelineActive ? _graphicsPipeline : _computePipeline;
+            if (pipeline == null) { return; }
+
+            pipeline.EnsureResourcesCreated();
+
+            if (!pipeline.HasPushConstantBuffer)
+            {
+                return;
+            }
+
+            // PushConstantGLBuffer is a raw uint GL handle, not an OpenGLBuffer wrapper
+            uint glBuffer = pipeline.PushConstantGLBuffer;
+
+            if (_extensions.ARB_DirectStateAccess)
+            {
+                _gl.NamedBufferSubData(
+                    glBuffer,
+                    (IntPtr)offsetInBytes,
+                    sizeInBytes,
+                    dataPtr.ToPointer());
+                CheckLastError();
+            }
+            else
+            {
+                _gl.BindBuffer(BufferTargetARB.UniformBuffer, glBuffer);
+                CheckLastError();
+                _gl.BufferSubData(
+                    BufferTargetARB.UniformBuffer,
+                    (IntPtr)offsetInBytes,
+                    (UIntPtr)sizeInBytes,
+                    dataPtr.ToPointer());
+                CheckLastError();
+            }
+
+            // PushConstantBindingSlot is the public property name, not PushConstantBindingPoint
+            _gl.UniformBlockBinding(pipeline.Program, pipeline.PushConstantBlockIndex, pipeline.PushConstantBindingSlot);
+            CheckLastError();
+            _gl.BindBufferBase(BufferTargetARB.UniformBuffer, pipeline.PushConstantBindingSlot, glBuffer);
+            CheckLastError();
+        }
+
         public void UpdateTexture(
             Texture texture,
             IntPtr dataPtr,

--- a/src/NeoVeldrid/OpenGL/OpenGLCommandList.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLCommandList.cs
@@ -157,6 +157,11 @@ namespace NeoVeldrid.OpenGL
             _currentCommands.UpdateBuffer(buffer, bufferOffsetInBytes, source, sizeInBytes);
         }
 
+        private protected override void PushConstantsCore(uint offsetInBytes, IntPtr source, uint sizeInBytes)
+        {
+            _currentCommands.PushConstants(offsetInBytes, source, sizeInBytes);
+        }
+
         private protected override void CopyBufferCore(
             DeviceBuffer source,
             uint sourceOffset,

--- a/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
@@ -40,6 +40,18 @@ namespace NeoVeldrid.OpenGL
 
         public uint Program => _program;
 
+        private const string PushConstantBlockName = "_PushConstants";
+        private const uint PushConstantBindingPoint = 15; // Reserved slot, away from regular UBOs
+        private const uint PushConstantBufferSize = 128;  // Max push constant size in bytes
+
+        private uint _pushConstantBuffer;
+        private uint _pushConstantBlockIndex = GL_INVALID_INDEX;
+
+        public bool HasPushConstantBuffer => _pushConstantBlockIndex != GL_INVALID_INDEX;
+        public uint PushConstantBlockIndex => _pushConstantBlockIndex;
+        public uint PushConstantBindingSlot => PushConstantBindingPoint;
+        public uint PushConstantGLBuffer => _pushConstantBuffer;
+
         public uint GetUniformBufferCount(uint setSlot) => _setInfos[setSlot].UniformBufferCount;
         public uint GetShaderStorageBufferCount(uint setSlot) => _setInfos[setSlot].ShaderStorageBufferCount;
 
@@ -158,6 +170,7 @@ namespace NeoVeldrid.OpenGL
                 throw new NeoVeldridException($"Error linking GL program: {log}");
             }
 
+            SetupPushConstants();
             ProcessResourceSetLayouts(ResourceLayouts);
         }
 
@@ -170,6 +183,38 @@ namespace NeoVeldrid.OpenGL
         void BindAttribLocation(uint slot, string elementName)
         {
             _gl.BindAttribLocation(_program, slot, elementName);
+            CheckLastError();
+        }
+
+        private void SetupPushConstants()
+        {
+            _pushConstantBlockIndex = _gl.GetUniformBlockIndex(_program, PushConstantBlockName);
+            CheckLastError();
+
+            if (_pushConstantBlockIndex == GL_INVALID_INDEX)
+            {
+                return; // Shader doesn't use push constants, nothing to do
+            }
+
+            // Create the dedicated UBO for push constant data
+            _gl.GenBuffers(1, out _pushConstantBuffer);
+            CheckLastError();
+
+            _gl.BindBuffer(BufferTargetARB.UniformBuffer, _pushConstantBuffer);
+            CheckLastError();
+
+            _gl.BufferData(
+                BufferTargetARB.UniformBuffer,
+                PushConstantBufferSize,
+                null,
+                BufferUsageARB.DynamicDraw);
+            CheckLastError();
+
+            _gl.BindBuffer(BufferTargetARB.UniformBuffer, 0);
+            CheckLastError();
+
+            // Permanently bind the block to our reserved binding point
+            _gl.UniformBlockBinding(_program, _pushConstantBlockIndex, PushConstantBindingPoint);
             CheckLastError();
         }
 
@@ -441,6 +486,12 @@ namespace NeoVeldrid.OpenGL
                 _disposed = true;
                 _gl.DeleteProgram(_program);
                 CheckLastError();
+
+                if (_pushConstantBuffer != 0)
+                {
+                    _gl.DeleteBuffers(1, in _pushConstantBuffer);
+                    CheckLastError();
+                }
             }
         }
     }

--- a/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
+++ b/src/NeoVeldrid/OpenGL/OpenGLPipeline.cs
@@ -188,32 +188,19 @@ namespace NeoVeldrid.OpenGL
 
         private void SetupPushConstants()
         {
-            _pushConstantBlockIndex = _gl.GetUniformBlockIndex(_program, PushConstantBlockName);
+            _pushConstantBlockIndex = _gl.GetUniformBlockIndex(_program, "_PushConstants");
             CheckLastError();
 
-            if (_pushConstantBlockIndex == GL_INVALID_INDEX)
-            {
-                return; // Shader doesn't use push constants, nothing to do
-            }
+            if (_pushConstantBlockIndex == GL_INVALID_INDEX) { return; }
 
-            // Create the dedicated UBO for push constant data
             _gl.GenBuffers(1, out _pushConstantBuffer);
             CheckLastError();
-
             _gl.BindBuffer(BufferTargetARB.UniformBuffer, _pushConstantBuffer);
             CheckLastError();
-
-            _gl.BufferData(
-                BufferTargetARB.UniformBuffer,
-                PushConstantBufferSize,
-                null,
-                BufferUsageARB.DynamicDraw);
+            _gl.BufferData(BufferTargetARB.UniformBuffer, PushConstantBufferSize, null, BufferUsageARB.DynamicDraw);
             CheckLastError();
-
             _gl.BindBuffer(BufferTargetARB.UniformBuffer, 0);
             CheckLastError();
-
-            // Permanently bind the block to our reserved binding point
             _gl.UniformBlockBinding(_program, _pushConstantBlockIndex, PushConstantBindingPoint);
             CheckLastError();
         }

--- a/src/NeoVeldrid/Vk/VkCommandList.cs
+++ b/src/NeoVeldrid/Vk/VkCommandList.cs
@@ -748,6 +748,19 @@ namespace NeoVeldrid.Vk
             CopyBuffer(stagingBuffer, 0, buffer, bufferOffsetInBytes, sizeInBytes);
         }
 
+        private protected override void PushConstantsCore(uint offsetInBytes, IntPtr source, uint sizeInBytes)
+        {
+            EnsureRenderPassActive();
+
+            _gd.Vk.CmdPushConstants(
+                _cb,
+                _currentGraphicsPipeline.PipelineLayout,
+                ShaderStageFlags.AllGraphics,
+                offsetInBytes,
+                sizeInBytes,
+                source.ToPointer());
+        }
+
         private protected override void CopyBufferCore(
             DeviceBuffer source,
             uint sourceOffset,


### PR DESCRIPTION
## What does this PR do?

Adds push constant support across all NeoVeldrid backends, allowing small amounts of frequently-updated data to be pushed directly into the command stream without the overhead of a buffer update.

**Backends:**
- **Vulkan** — uses native `vkCmdPushConstants`
- **D3D11** — emulated via a dedicated `Map/WriteDiscard` constant buffer bound to reserved slot `b13`
- **OpenGL/ESSL** — emulated via a dedicated UBO bound to reserved binding point 15, with the push constant block emitted as a proper UBO by spirv-cross

**Files changed:**
- `CommandList.cs` — adds `PushConstants<T>`, `PushConstants<T>(ref T)`, and `PushConstants(IntPtr)` public API with 128-byte portable size limit documented
- `OpenGL/OpenGLCommandList.cs` — delegates to entry list
- `OpenGL/OpenGLCommandEntryList.cs` (interface) — adds `PushConstants` method
- `OpenGL/NoAllocEntryList/OpenGLNoAllocCommandEntryList.cs` — records push constant entries into the no-alloc command list via staging memory
- `OpenGL/OpenGLCommandExecutor.cs` — executes push constants by updating the pipeline's dedicated UBO
- `OpenGL/OpenGLPipeline.cs` — detects `_PushConstants` uniform block at link time, creates and owns the dedicated UBO
- `Vk/VkCommandList.cs` — implements via `vkCmdPushConstants`
- `D3D11/D3D11CommandList.cs` — implements via `Map/WriteDiscard` on a dedicated constant buffer
- `NeoVeldrid.SPIRV/SpirvCrossCompiler.cs` — remaps push constant blocks to `b13` for HLSL, forces UBO emission for GLSL/ESSL via `GlslEmitPushConstantAsUniformBuffer`, and renames the block to `_PushConstants` so OpenGL can find it by name

**Usage:**
```glsl
// In your GLSL shader
layout(push_constant) uniform _PushConstants {
    mat4 model;
    vec4 color;
} pc;
```
```csharp
// In your C# code
commandList.SetPipeline(pipeline);
commandList.PushConstants(0, myStruct);
commandList.DrawIndexed(...);
```

**Limitations:**
- Maximum portable push constant size is 128 bytes (Vulkan spec minimum guarantee)
- The push constant block must be named `_PushConstants` in GLSL source
- D3D11 reserves constant buffer slot `b13`; shaders may use `b0`–`b12` for regular uniform buffers
- OpenGL reserves UBO binding point 15

## Related Issues

<!-- Link any related issues -->

## Tests

Only check the platforms where you actually ran the tests:

- [x] Tests pass on Windows
- [ ] Tests pass on Linux
- [ ] Tests pass on macOS
- [x] Samples tested visually (if rendering code was changed)
- [x] No unrelated changes included